### PR TITLE
Detect the broadcast intent is from SMS Retriever API by adding the SmsRetriever.SEND_PERMISSION permission to receiver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Detect the broadcast intent is from SMS Retriever API by adding
+* the SmsRetriever.SEND_PERMISSION permission to receiver.
+
 ## 0.1.0
 
 * Migrate to null safety. Credits to san-smith (https://github.com/san-smith) 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // for sms user consent
-    implementation 'com.google.android.gms:play-services-auth:20.0.0'
-    implementation 'com.google.android.gms:play-services-auth-api-phone:18.0.0'
+    implementation 'com.google.android.gms:play-services-auth:20.0.1'
+    implementation 'com.google.android.gms:play-services-auth-api-phone:18.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // for sms user consent
-    implementation 'com.google.android.gms:play-services-auth:18.1.0'
-    implementation 'com.google.android.gms:play-services-auth-api-phone:17.4.0'
+    implementation 'com.google.android.gms:play-services-auth:20.0.0'
+    implementation 'com.google.android.gms:play-services-auth-api-phone:18.0.0'
 }

--- a/android/src/main/kotlin/dev/pharsh/sms_user_consent/SmsUserConsentPlugin.kt
+++ b/android/src/main/kotlin/dev/pharsh/sms_user_consent/SmsUserConsentPlugin.kt
@@ -42,7 +42,7 @@ class SmsUserConsentPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "requestSms" -> {
                 SmsRetriever.getClient(mActivity.applicationContext).startSmsUserConsent(call.argument<String>("senderPhoneNumber"))
 
-                mActivity.registerReceiver(smsVerificationReceiver, IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION))
+                mActivity.registerReceiver(smsVerificationReceiver, IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION), SmsRetriever.SEND_PERMISSION, null);
                 result.success(null)
             }
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sms_user_consent
 description: Request user's phone number (supports dual sim) and/or consent to read SMS without adding any permissions
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/pharshdev/sms_user_consent
 
 environment:


### PR DESCRIPTION
I got the Intent Redirection vulnerability error from Play Store;
![play-store-error](https://user-images.githubusercontent.com/3121947/146600005-da718a94-4aa4-4b58-a1d3-272ad206ce67.png)

So I added the SmsRetriever.SEND_PERMISSION permission to receiver as described in the docs below.

[Remediation for Intent Redirection Vulnerability](https://support.google.com/faqs/answer/9267555) <- Google Help Center article
[Request one-time consent to read an SMS verification code](https://developers.google.com/identity/sms-retriever/user-consent/request)
