### PR TITLE
fix: update pubspec repo and settings, consent for new Android versions, add ProGuard rules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'dev.pharsh.sms_user_consent'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -25,13 +25,23 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    namespace "dev.pharsh.sms_user_consent"
+    compileSdkVersion 33
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
+        consumerProguardFiles 'consumer-rules.pro' 
         minSdkVersion 21
     }
     lintOptions {
@@ -52,6 +53,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // for sms user consent
-    implementation 'com.google.android.gms:play-services-auth:18.1.0'
-    implementation 'com.google.android.gms:play-services-auth-api-phone:17.4.0'
+    implementation 'com.google.android.gms:play-services-auth:20.7.0'
+    implementation 'com.google.android.gms:play-services-auth-api-phone:18.0.1'
 }

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,7 @@
+# Keep Google Play Services Auth API classes
+-keep class com.google.android.gms.auth.api.credentials.** { *; }
+-dontwarn com.google.android.gms.auth.api.credentials.**
+
+# Keep SMS User Consent Plugin classes
+-keep class dev.pharsh.sms_user_consent.** { *; }
+-dontwarn dev.pharsh.sms_user_consent.**

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'sms_user_consent'
+include ':sms_user_consent'

--- a/android/src/main/kotlin/dev/pharsh/sms_user_consent/SmsUserConsentPlugin.kt
+++ b/android/src/main/kotlin/dev/pharsh/sms_user_consent/SmsUserConsentPlugin.kt
@@ -42,7 +42,11 @@ class SmsUserConsentPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "requestSms" -> {
                 SmsRetriever.getClient(mActivity.applicationContext).startSmsUserConsent(call.argument<String>("senderPhoneNumber"))
 
-                mActivity.registerReceiver(smsVerificationReceiver, IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION))
+                mActivity.registerReceiver(
+                    smsVerificationReceiver,
+                    IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION),
+                    Context.RECEIVER_EXPORTED
+                )
                 result.success(null)
             }
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sms_user_consent
 description: Request user's phone number (supports dual sim) and/or consent to read SMS without adding any permissions
 version: 0.1.0
-repository: https://github.com/pharshdev/sms_user_consent
+repository: https://github.com/tonsoo/sms_user_consent.git
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
This PR includes fixes and improvements for:
- Pubspec: updated the repository reference.
- Settings: ensured missing configuration is included.
- Android Consent: fixed handling of consent for newer Android versions to prevent crashes.
- ProGuard: added consumer rules to resolve R8 minification issues (#1).